### PR TITLE
Disable configuration detect logic

### DIFF
--- a/lib/language_pack/ruby.rb
+++ b/lib/language_pack/ruby.rb
@@ -108,8 +108,6 @@ WARNING
         install_binaries
         run_assets_precompile_rake_task
       end
-      config_detect
-      best_practice_warnings
       cleanup
       super
     end


### PR DESCRIPTION
Context: https://github.com/intercom/intercom/issues/120335

The Heroku ruby buildpack added logic this year to give best practice warnings for certain configuration settings.  However, this logic requires an application boot which is pretty expensive for us.  The configuration logic has a 65s timeout which is ALWAYS hit: https://github.com/intercom/intercom/issues/120335.   This adds 65 seconds to our end-to-end deploy time for Intercom.  This has been failing for months and no-one noticed.  Even if logic was working, generating warnings in our slugging log in not an effective way of enforcing best practices for us: we're probably not going to see them anyway.  This functionality is not just worthless for us - it has negative value given the overhead of an additional Rails application boot.

To address reliablity problems with slugging (see linked issue above) and to improve our end-to-end times, we've forked the buildpack.  This PR disables Heroku's config detection and best practices logic entirely.  