### PR TITLE
Disable config detection

### DIFF
--- a/lib/language_pack/rails2.rb
+++ b/lib/language_pack/rails2.rb
@@ -18,7 +18,6 @@ class LanguagePack::Rails2 < LanguagePack::Ruby
 
   def initialize(build_path, cache_path=nil)
     super(build_path, cache_path)
-    @rails_runner = LanguagePack::Helpers::RailsRunner.new
   end
 
   def name

--- a/lib/language_pack/rails3.rb
+++ b/lib/language_pack/rails3.rb
@@ -44,9 +44,6 @@ class LanguagePack::Rails3 < LanguagePack::Rails2
   end
 
   def config_detect
-    super
-    @assets_compile_config = @rails_runner.detect("assets.compile")
-    @x_sendfile_config     = @rails_runner.detect("action_dispatch.x_sendfile_header")
   end
 
   def best_practice_warnings

--- a/lib/language_pack/rails4.rb
+++ b/lib/language_pack/rails4.rb
@@ -68,7 +68,6 @@ WARNING
 
   def cleanup
     super
-    return if assets_compile_enabled?
     return unless Dir.exist?(default_assets_cache)
     FileUtils.remove_dir(default_assets_cache)
   end

--- a/lib/language_pack/rails5.rb
+++ b/lib/language_pack/rails5.rb
@@ -32,8 +32,6 @@ class LanguagePack::Rails5 < LanguagePack::Rails42
   end
 
   def config_detect
-    super
-    @local_storage_config = @rails_runner.detect("active_storage.service")
   end
 
   def best_practice_warnings


### PR DESCRIPTION
This PR disables config checks for all ruby versions and removes the compiled assets check in our cleanup logic.

