### PR TITLE
Bump Bundler to 1.15.2.1

### DIFF
--- a/lib/language_pack/ruby.rb
+++ b/lib/language_pack/ruby.rb
@@ -16,7 +16,7 @@ class LanguagePack::Ruby < LanguagePack::Base
   NAME                 = "ruby"
   LIBYAML_VERSION      = "0.1.7"
   LIBYAML_PATH         = "libyaml-#{LIBYAML_VERSION}"
-  BUNDLER_VERSION      = "1.15.2"
+  BUNDLER_VERSION      = "1.15.2.1"
   BUNDLER_GEM_PATH     = "bundler-#{BUNDLER_VERSION}"
   RBX_BASE_URL         = "http://binaries.rubini.us/heroku"
   NODE_BP_PATH         = "vendor/node/bin"


### PR DESCRIPTION
I built this fictitious Bundler version by applying the following patch to Bundler 1.15.2:

https://github.com/bundler/bundler/commit/fbab11810635b6c0843446320e7902186c7c715c

This will allow us to use Bundler plugins in production without having to upgrade to Bundler 2.