### PR TITLE
Bump Bundler to 1.15.2.2

### DIFF
--- a/lib/language_pack/ruby.rb
+++ b/lib/language_pack/ruby.rb
@@ -16,7 +16,7 @@ class LanguagePack::Ruby < LanguagePack::Base
   NAME                 = "ruby"
   LIBYAML_VERSION      = "0.1.7"
   LIBYAML_PATH         = "libyaml-#{LIBYAML_VERSION}"
-  BUNDLER_VERSION      = "1.15.2.1"
+  BUNDLER_VERSION      = "1.15.2.2"
   BUNDLER_GEM_PATH     = "bundler-#{BUNDLER_VERSION}"
   RBX_BASE_URL         = "http://binaries.rubini.us/heroku"
   NODE_BP_PATH         = "vendor/node/bin"


### PR DESCRIPTION
This version includes the following patch on top of 1.15.2.1:

```patch
diff --git a/lib/bundler/plugin/index.rb b/lib/bundler/plugin/index.rb
index 8dde072f1..947b7a3f4 100644
--- a/lib/bundler/plugin/index.rb
+++ b/lib/bundler/plugin/index.rb
@@ -128,8 +128,8 @@ module Bundler

           @commands.merge!(index["commands"])
           @hooks.merge!(index["hooks"])
-          @load_paths.merge!(index["load_paths"])
-          @plugin_paths.merge!(index["plugin_paths"])
+          @load_paths.merge!(index["load_paths"].transform_values { |load_paths| load_paths.map { |load_path| [Plugin.root, load_path].join } })
+          @plugin_paths.merge!(index["plugin_paths"].transform_values { |plugin_path| [Plugin.root, plugin_path].join })
           @sources.merge!(index["sources"]) unless global
         end
       end
@@ -141,8 +141,8 @@ module Bundler
         index = {
           "commands"     => @commands,
           "hooks"        => @hooks,
-          "load_paths"   => @load_paths,
-          "plugin_paths" => @plugin_paths,
+          "load_paths"   => @load_paths.transform_values { |load_paths| load_paths.map { |load_path| load_path.reverse.chomp(Plugin.root.to_s.reverse).reverse }},
+          "plugin_paths" => @plugin_paths.transform_values { |plugin_path| plugin_path.reverse.chomp(Plugin.root.to_s.reverse).reverse },
           "sources"      => @sources,
         }
```

By storing relative paths in the plugin index file, building a slug in one location and running it in another will work correctly again. This partially fixes https://github.com/bundler/bundler/issues/6943, but only for locally installed plugins, not global ones; a proper upstream fix will need to address both.