### PR TITLE
Revert "Parallelise Bundle install by the number of processes"

### DIFF
--- a/lib/language_pack/ruby.rb
+++ b/lib/language_pack/ruby.rb
@@ -1,5 +1,4 @@
 require "tmpdir"
-require "etc"
 require "digest/md5"
 require "benchmark"
 require "rubygems"
@@ -635,7 +634,7 @@ BUNDLE
         bundle_without = env("BUNDLE_WITHOUT") || default_bundle_without
         bundle_bin     = "bundle"
         bundle_command = "#{bundle_bin} install --without #{bundle_without} --path vendor/bundle --binstubs #{bundler_binstubs_path}"
-        bundle_command << " -j#{Etc.nprocessors}"
+        bundle_command << " -j4"
 
         if File.exist?("#{Dir.pwd}/.bundle/config")
           warn(<<-WARNING, inline: true)


### PR DESCRIPTION
Reverts intercom/heroku-buildpack-ruby#5

We're seeing some weird Gem::RemoteFetcher::FetchError: Net::OpenTimeout: execution expired
exceptions and we believe it's down to the high number of CPUs (aka Bundler parallel jobs) and
scheduling not happening in an equal fashion, resulting in a thread that was fetching getting descheduled
for > 10s and throwing this error. 

Let's go back to a fixed 4 jobs