### PR TITLE
Bump to Bundler 1.15.2.3

### DIFF
--- a/lib/language_pack/ruby.rb
+++ b/lib/language_pack/ruby.rb
@@ -16,7 +16,7 @@ class LanguagePack::Ruby < LanguagePack::Base
   NAME                 = "ruby"
   LIBYAML_VERSION      = "0.1.7"
   LIBYAML_PATH         = "libyaml-#{LIBYAML_VERSION}"
-  BUNDLER_VERSION      = "1.15.2.2"
+  BUNDLER_VERSION      = "1.15.2.3"
   BUNDLER_GEM_PATH     = "bundler-#{BUNDLER_VERSION}"
   RBX_BASE_URL         = "http://binaries.rubini.us/heroku"
   NODE_BP_PATH         = "vendor/node/bin"


### PR DESCRIPTION
Another fictitious Bundler version with the following patch that removes calls to `#untaint` so we stop destroying the build logs with deprecation warnings.

```patch
diff --git a/lib/bundler/dsl.rb b/lib/bundler/dsl.rb
index e4c257d267..15e6a0ff4b 100644
--- a/lib/bundler/dsl.rb
+++ b/lib/bundler/dsl.rb
@@ -38,7 +38,7 @@ module Bundler
       original_gemfile = @gemfile
       @gemfile = expanded_gemfile_path
       contents ||= Bundler.read_file(gemfile.to_s)
-      instance_eval(contents.dup.untaint, gemfile.to_s, 1)
+      instance_eval(contents.dup, gemfile.to_s, 1)
     rescue Exception => e
       message = "There was an error " \
         "#{e.is_a?(GemfileEvalError) ? "evaluating" : "parsing"} " \

diff --git a/lib/bundler/shared_helpers.rb b/lib/bundler/shared_helpers.rb
index 74700cde35..67f8e5eedf 100644
--- a/lib/bundler/shared_helpers.rb
+++ b/lib/bundler/shared_helpers.rb
@@ -22,7 +22,7 @@ module Bundler
     def default_gemfile
       gemfile = find_gemfile
       raise GemfileNotFound, "Could not locate Gemfile" unless gemfile
-      Pathname.new(gemfile).untaint
+      Pathname.new(gemfile)
     end
 
     def default_lockfile
@@ -31,7 +31,7 @@ module Bundler
       case gemfile.basename.to_s
       when "gems.rb" then Pathname.new(gemfile.sub(/.rb$/, ".locked"))
       else Pathname.new("#{gemfile}.lock")
-      end.untaint
+      end
     end
 
     def default_bundle_dir
@@ -105,7 +105,7 @@ module Bundler
     def filesystem_access(path, action = :write, &block)
       # Use block.call instead of yield because of a bug in Ruby 2.2.2
       # See https://github.com/bundler/bundler/issues/5341 for details
-      block.call(path.dup.untaint)
+      block.call(path.dup)
     rescue Errno::EACCES
       raise PermissionError.new(path, action)
     rescue Errno::EAGAIN
@@ -192,7 +192,7 @@ module Bundler
 
     def search_up(*names)
       previous = nil
-      current  = File.expand_path(SharedHelpers.pwd).untaint
+      current  = File.expand_path(SharedHelpers.pwd)
 
       until !File.directory?(current) || current == previous
         if ENV["BUNDLE_SPEC_RUN"]
diff --git a/lib/bundler/source/git.rb b/lib/bundler/source/git.rb
index b3e218e390..053dab9087 100644
--- a/lib/bundler/source/git.rb
+++ b/lib/bundler/source/git.rb
@@ -315,7 +315,7 @@ module Bundler
       if Bundler.rubygems.stubs_provide_full_functionality?
         def load_gemspec(file)
           stub = Gem::StubSpecification.gemspec_stub(file, install_path.parent, install_path.parent)
-          stub.full_gem_path = Pathname.new(file).dirname.expand_path(root).to_s.untaint
+          stub.full_gem_path = Pathname.new(file).dirname.expand_path(root).to_s
           StubSpecification.from_stub(stub)
         end
       end
diff --git a/lib/bundler/version.rb b/lib/bundler/version.rb
index f1c9b1d13e..c6af8d02ea 100644
--- a/lib/bundler/version.rb
+++ b/lib/bundler/version.rb
@@ -7,7 +7,7 @@ module Bundler
   # We're doing this because we might write tests that deal
   # with other versions of bundler and we are unsure how to
   # handle this better.
-  VERSION = "1.15.2" unless defined?(::Bundler::VERSION)
+  VERSION = "1.15.2.3" unless defined?(::Bundler::VERSION)
 
   def self.overwrite_loaded_gem_version
     begin
```